### PR TITLE
Floormap: local autosave + draft restore

### DIFF
--- a/src/components/floormap/Toolbar.jsx
+++ b/src/components/floormap/Toolbar.jsx
@@ -6,6 +6,7 @@ import { useRef } from 'react'
 export default function Toolbar({
   onDetectRooms, onExport, onAddRoom, onClearAll, onImportJson,
   isDetecting, isExporting, hasImage, hasRooms,
+  hasDraft, lastSavedAt, onSaveDraftNow, onRestoreDraft, onClearDraft,
 }) {
   const handleAddRoom = () => onAddRoom?.({ x: 100, y: 100, width: 80, height: 60 })
   const inputRef = useRef(null)
@@ -60,6 +61,33 @@ export default function Toolbar({
         className="px-3 py-1.5 text-sm font-medium rounded-md border border-rose-200 text-rose-700 hover:bg-rose-50 disabled:opacity-50 disabled:cursor-not-allowed">
         Clear All
       </button>
+      <button
+        type="button"
+        onClick={onSaveDraftNow}
+        disabled={!hasImage && !hasRooms}
+        className="px-3 py-1.5 text-sm font-medium rounded-md border border-emerald-300 text-emerald-700 hover:bg-emerald-50 disabled:opacity-50 disabled:cursor-not-allowed"
+        title="Save in-progress floor map locally"
+      >
+        Save Draft
+      </button>
+      <button
+        type="button"
+        onClick={onRestoreDraft}
+        disabled={!hasDraft}
+        className="px-3 py-1.5 text-sm font-medium rounded-md border border-indigo-300 text-indigo-700 hover:bg-indigo-50 disabled:opacity-50 disabled:cursor-not-allowed"
+        title="Restore most recent local draft"
+      >
+        Restore Draft
+      </button>
+      <button
+        type="button"
+        onClick={onClearDraft}
+        disabled={!hasDraft}
+        className="px-3 py-1.5 text-sm font-medium rounded-md border border-slate-300 text-slate-700 hover:bg-slate-50 disabled:opacity-50 disabled:cursor-not-allowed"
+        title="Delete local draft"
+      >
+        Clear Draft
+      </button>
       <button type="button" onClick={handleImportClick}
         className="px-3 py-1.5 text-sm font-medium rounded-md border border-slate-300 text-slate-700 hover:bg-slate-50 flex items-center gap-2"
         title="Load a previously exported floor map JSON">
@@ -67,6 +95,10 @@ export default function Toolbar({
         Import JSON
       </button>
       <input ref={inputRef} type="file" accept=".json,application/json" onChange={handleImportChange} className="hidden" />
+      <p className="ml-auto text-[11px] text-slate-500">
+        Local draft: {hasDraft ? 'saved' : 'not saved'}
+        {lastSavedAt ? ` (${new Date(lastSavedAt).toLocaleTimeString()})` : ''}
+      </p>
     </div>
   )
 }

--- a/src/pages/FloorMapAIPage.jsx
+++ b/src/pages/FloorMapAIPage.jsx
@@ -2,7 +2,7 @@
  * FloorMap AI - Floor plan room detection and ER bed map export.
  * Integrated into NM2-Analytics-Shorts; uses separate FastAPI backend.
  */
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import Header from '../components/floormap/Header'
 import ImageUpload from '../components/floormap/ImageUpload'
 import { FloorPlanCanvas } from '../components/floormap/FloorPlanCanvas'
@@ -10,6 +10,8 @@ import RoomEditor from '../components/floormap/RoomEditor'
 import Toolbar from '../components/floormap/Toolbar'
 import { useFloorMap } from '../hooks/useFloorMap'
 import { floormapApi } from '../api/floormapClient'
+
+const FLOOR_MAP_DRAFT_KEY = 'nm2.floormap.draft.v1'
 
 export default function FloorMapAIPage() {
   const {
@@ -28,6 +30,69 @@ export default function FloorMapAIPage() {
   const [isDetecting, setIsDetecting] = useState(false)
   const [isExporting, setIsExporting] = useState(false)
   const [imageDimensions, setImageDimensions] = useState({ width: 0, height: 0 })
+  const [lastSavedAt, setLastSavedAt] = useState(null)
+  const [hasDraft, setHasDraft] = useState(false)
+  const didHydrateDraftRef = useRef(false)
+
+  const persistDraft = useCallback((overrideData = null) => {
+    if (typeof window === 'undefined') return false
+    const data = overrideData || {
+      floorPlanImage,
+      rooms,
+      selectedRoomId,
+      imageDimensions,
+      savedAt: Date.now(),
+    }
+    const hasAnyData = !!data.floorPlanImage || (Array.isArray(data.rooms) && data.rooms.length > 0)
+    if (!hasAnyData) {
+      window.localStorage.removeItem(FLOOR_MAP_DRAFT_KEY)
+      setHasDraft(false)
+      return false
+    }
+    window.localStorage.setItem(FLOOR_MAP_DRAFT_KEY, JSON.stringify(data))
+    setHasDraft(true)
+    setLastSavedAt(data.savedAt || Date.now())
+    return true
+  }, [floorPlanImage, imageDimensions, rooms, selectedRoomId])
+
+  const clearSavedDraft = useCallback(() => {
+    if (typeof window === 'undefined') return
+    window.localStorage.removeItem(FLOOR_MAP_DRAFT_KEY)
+    setHasDraft(false)
+    setLastSavedAt(null)
+  }, [])
+
+  const restoreSavedDraft = useCallback(() => {
+    if (typeof window === 'undefined') return false
+    const raw = window.localStorage.getItem(FLOOR_MAP_DRAFT_KEY)
+    if (!raw) return false
+    try {
+      const parsed = JSON.parse(raw)
+      setFloorPlanImage(parsed.floorPlanImage || null)
+      setRooms(Array.isArray(parsed.rooms) ? parsed.rooms : [])
+      setSelectedRoomId(parsed.selectedRoomId || null)
+      setImageDimensions(parsed.imageDimensions || { width: 0, height: 0 })
+      setHasDraft(true)
+      setLastSavedAt(parsed.savedAt || Date.now())
+      return true
+    } catch (err) {
+      console.error('Failed to restore FloorMap draft:', err)
+      return false
+    }
+  }, [setFloorPlanImage, setRooms, setSelectedRoomId])
+
+  useEffect(() => {
+    if (didHydrateDraftRef.current) return
+    didHydrateDraftRef.current = true
+    restoreSavedDraft()
+  }, [restoreSavedDraft])
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      persistDraft()
+    }, 600)
+    return () => window.clearTimeout(timer)
+  }, [persistDraft])
 
   const handleImageUpload = useCallback(
     async (file) => {
@@ -134,6 +199,11 @@ export default function FloorMapAIPage() {
             isExporting={isExporting}
             hasImage={!!floorPlanImage}
             hasRooms={rooms.length > 0}
+            hasDraft={hasDraft}
+            lastSavedAt={lastSavedAt}
+            onSaveDraftNow={() => persistDraft()}
+            onRestoreDraft={restoreSavedDraft}
+            onClearDraft={clearSavedDraft}
           />
           <div className="flex-1 flex overflow-hidden">
             {floorPlanImage ? (


### PR DESCRIPTION
## Summary\nThis PR adds a local (browser) draft autosave to the FloorMap editor so in-progress work survives refresh/crashes.\n\n## User impact\n- Autosave draft persists to localStorage while editing\n- Save Draft, Restore Draft, and Clear Draft buttons in the floormap toolbar\n\n## Files changed\n- src/pages/FloorMapAIPage.jsx\n- src/components/floormap/Toolbar.jsx\n

Made with [Cursor](https://cursor.com)